### PR TITLE
Fix error with center_onset and allow user to modify seizure window

### DIFF
--- a/Code/dynamic_ISH/code/connectivity_dynamics.py
+++ b/Code/dynamic_ISH/code/connectivity_dynamics.py
@@ -790,7 +790,7 @@ def center_onset(peri_df: pd.DataFrame, win_size=5, stride=1, center_designation
     
     return pd.concat(centered_dfs)
 
-def center_event_df(win_size, stride, center_designations, event_df, **kwargs)-> pd.DataFrame:
+def center_event_df(win_size, stride, center_designations, event_df, start_buffer=10, end_buffer=10, mid_sz_length=10)-> pd.DataFrame:
     """center an event_level data frame: see center_onset above
 
     Args:
@@ -818,14 +818,14 @@ def center_event_df(win_size, stride, center_designations, event_df, **kwargs)->
     else:
         sz_end =  get_sz_end(event_df)
         event_df.insert(loc=0,column='sz_end', value =sz_end)
-        sz_st_end = sample_seizures(event_df, start_buffer=10, end_buffer=10, mid_sz_length=10, win_size=5)
+        sz_st_end = sample_seizures(event_df, start_buffer=start_buffer, end_buffer=end_buffer, mid_sz_length=mid_sz_length, win_size=win_size)
         event_df.insert(loc=0,column='win_sz_st_end', value = sz_st_end)
         labelled_window = event_df.parallel_apply(label_window, args=[win_size, stride], axis=1)
         event_df.insert(loc=0,column='win_label', value = labelled_window)
     centered_event_df = event_df
     return centered_event_df
 
-def sample_seizures(peri_df, start_buffer=15, end_buffer=15, mid_sz_length=5, win_size=5, stride=1):
+def sample_seizures(peri_df, start_buffer, end_buffer, mid_sz_length, win_size=5, stride=1):
     """
     Returns index tracking all windows with zero centered at seizure onset and all seizures
     ending at the same time. Seizure window is determined by length of start_buffer + end_buffer + mid_sz_length
@@ -849,8 +849,6 @@ def sample_seizures(peri_df, start_buffer=15, end_buffer=15, mid_sz_length=5, wi
 
     # Buffers define the minimally acceptable seizure length
     if sz_end < (start_buffer + mid_sz_length + end_buffer):
-        logger.warning(f"{peri_df.patID} event {peri_df.eventID} has a seizure length of {sz_end}",
-                       f"which is shorter than minimally acceptable length of {start_buffer+mid_sz_length+end_buffer}")
         return [np.nan for _ in range(peri_df.shape[0])]
 
     # pull out all windows leading up to (or after) seizure and the transition windows that we will preserve

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ scikit_learn==1.5.1
 scipy==1.14.0
 seaborn==0.13.2
 tqdm==4.66.4
-pandaralell==1.6.5
+pandarallel==1.6.5


### PR DESCRIPTION
- Fixes error with center_onset by mandating that the eventID column is set to type str
- Allows user to pass kwargs dictionary into center_onset with keys start_buffer, end_buffer, and/or mid_sz_length specified